### PR TITLE
Conditional branching of output directory

### DIFF
--- a/build-tools/msvc/tools/get_libzstd.bat
+++ b/build-tools/msvc/tools/get_libzstd.bat
@@ -23,7 +23,11 @@ MD %ZSTD_PACKAGE%
 CD %ZSTD_PACKAGE%
 cmake -E tar xvzf ..\%ZSTD_PACKAGE%.zip || GOTO :error
 
+IF NOT EXIST "%VENV%\Scripts" (
+MOVE dll\libzstd.dll %~p0\zstd.dll
+) ELSE (
 MOVE dll\libzstd.dll %VENV%\Scripts\zstd.dll
+)
 CD ..
 
 DEL %ZSTD_PACKAGE%.zip


### PR DESCRIPTION
If %VENV% is undefined, output the dll file in the same directory as the bat file.